### PR TITLE
Fix navigation support button

### DIFF
--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -2,7 +2,7 @@ describe("Sidebar Navigation", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000/dashboard");
   });
-
+  //
   context("desktop resolution", () => {
     beforeEach(() => {
       cy.viewport(1025, 900);
@@ -36,6 +36,18 @@ describe("Sidebar Navigation", () => {
 
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
+    });
+
+    it("opens email client", () => {
+      // keep click from opening new tab (from window.open)
+      cy.window().then((win) => {
+        cy.stub(win, "open").as("open");
+      });
+      cy.get("nav").contains("Support").click();
+      cy.get("@open").should(
+        "have.been.calledOnceWithExactly",
+        "mailto:support@prolog-app.com?subject=Support%20Request"
+      );
     });
   });
 

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -195,7 +195,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support%20Request"
+                )
+              }
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
This PR fixes the support button by opening the user's email client when clicked. Test coverage added for specifying the email recipient and subject line when the new window is opened. 