### PR TITLE
Fix navigation logo on mobile

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -74,6 +74,16 @@ const Logo = styled.img`
   @media (min-width: ${breakpoint("desktop")}) {
     margin: ${space(0, 4)};
   }
+
+  @media (max-width: ${breakpoint("desktop")}) {
+    display: none;
+  }
+`;
+
+const LogoMobile = styled.img`
+  @media (min-width: ${breakpoint("desktop")}) {
+    display: none;
+  }
 `;
 
 const MenuButton = styled(Button)`
@@ -170,6 +180,7 @@ export function SidebarNavigation() {
             }
             alt="logo"
           />
+          <LogoMobile src={"/icons/logo-large.svg"} alt="logo" />
           <MenuButton onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}>
             <MenuIcon
               src={isMobileMenuOpen ? "/icons/close.svg" : "/icons/menu.svg"}


### PR DESCRIPTION
This PR adds a new logo styled component to be shown when the user switches to mobile. Previously, when the navbar was collapsed, the logo to overflowed the container on mobile. 
Before
![image](https://user-images.githubusercontent.com/64967912/202832797-e9c11efa-2975-4128-b270-a818f70a98e9.png)

After
![image](https://user-images.githubusercontent.com/64967912/202832863-a69fdd1b-8c15-4cf0-ba7c-b062c55d031f.png)


